### PR TITLE
[DAS-515] Enhance custom selector

### DIFF
--- a/_forms.scss
+++ b/_forms.scss
@@ -236,6 +236,7 @@ fieldset {
     width: 0;
     height: 0;
     display: inline-block;
+    pointer-events: none;
   }
 
   &--disabled::after {


### PR DESCRIPTION
    Add 'pointer-events' css property to prevent
    the custom selector of overwriting its settings
    about mouse events, i.e. behave like a non-customized
    select tag.